### PR TITLE
Fix Community Default names being cut-off

### DIFF
--- a/ui/mods/hotbuild2/settings/hotbuild_settings.html
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.html
@@ -6,7 +6,7 @@
             <button class="btn btn-default btn-xs dropdown-toggle" id="hb_communitydefaults" type="button" data-toggle="dropdown" data-bind="click_sound: 'default', rollover_sound: 'default'">
                 Community Defaults <span class="caret"></span>
             </button>
-            <ul class="dropdown-menu">
+            <ul class="dropdown-menu pull-right">
                 <li><a href="#" data-bind="click:$data.showCommunityDefaultPrompt.bind($data,'wasd')">WASD (Qwerty)</a></li>
                 <li><a href="#" data-bind="click:$data.showCommunityDefaultPrompt.bind($data,'zqsd')">ZQSD (Azerty)</a></li>
                 <li><a href="#" data-bind="click:$data.showCommunityDefaultPrompt.bind($data,'arrows')">ARROWS (&#8592;&#8593;&#8594;&#8595;)</a></li>


### PR DESCRIPTION
The dropdown was being cut off by the settings' border, leading to "Arrows Quitch" not displaying in full. We change this to a `pull-right` class to resolve.