### PR TITLE
Look up the hotbuild key by name, not position

### DIFF
--- a/ui/mods/hotbuild2/live_game/hotbuild_buildbar.js
+++ b/ui/mods/hotbuild2/live_game/hotbuild_buildbar.js
@@ -16,23 +16,16 @@ var hotbuild2buildbar = (function () {
 
     hbgetBuildBarKey = function (id) {
         var result = '';
-        var hbpos = 1;
-        _.forEach(hotbuildglobal, function (hbkey) {
+        //the two configs are joined by property name, so look the key up by name
+        _.forEach(hotbuildglobal, function (hbkey, hbname) {
             _.forEach(hbkey, function (hbitem) {
-                if (hbitem.json === id) {
-                    if (hotbuildglobalkey["hotbuild" + hbpos + "s"] !== undefined) {
-                        result += hotbuildglobalkey["hotbuild" + hbpos + "s"];
-                        return false;
-                    }
-                }
-                if (hbitem.json + ".player" === id) {
-                    if (hotbuildglobalkey["hotbuild" + hbpos + "s"] !== undefined) {
-                        result += hotbuildglobalkey["hotbuild" + hbpos + "s"];
+                if (hbitem.json === id || hbitem.json + ".player" === id) {
+                    if (hotbuildglobalkey[hbname] !== undefined) {
+                        result += hotbuildglobalkey[hbname];
                         return false;
                     }
                 }
             });
-            hbpos += 1;
         });
         return result;
     };

--- a/ui/mods/hotbuild2/live_game/hotbuild_selection.js
+++ b/ui/mods/hotbuild2/live_game/hotbuild_selection.js
@@ -16,23 +16,16 @@ var hotbuild2selection = (function () {
 
     hbgetBuildBarKey = function (id) {
         var result = '';
-        var hbpos = 1;
-        _.forEach(hotbuildglobal, function (hbkey) {
+        //the two configs are joined by property name, so look the key up by name
+        _.forEach(hotbuildglobal, function (hbkey, hbname) {
             _.forEach(hbkey, function (hbitem) {
-                if (hbitem.json === id) {
-                    if (hotbuildglobalkey["hotbuild" + hbpos + "s"] !== undefined) {
-                        result += hotbuildglobalkey["hotbuild" + hbpos + "s"];
-                        return false;
-                    }
-                }
-                if (hbitem.json + ".player" === id) {
-                    if (hotbuildglobalkey["hotbuild" + hbpos + "s"] !== undefined) {
-                        result += hotbuildglobalkey["hotbuild" + hbpos + "s"];
+                if (hbitem.json === id || hbitem.json + ".player" === id) {
+                    if (hotbuildglobalkey[hbname] !== undefined) {
+                        result += hotbuildglobalkey[hbname];
                         return false;
                     }
                 }
             });
-            hbpos += 1;
         });
         return result;
     };


### PR DESCRIPTION
hbgetBuildBarKey walked hotbuildglobal with a counter and read hotbuildglobalkey["hotbuild" + n + "s"], so the two objects had to be both sequentially numbered and iterated in the same order. Save() keeps that true for configs it writes, but a hand-edited localStorage, a .pas from an older version, or a hotbuildglobalkey holding a key hotbuildglobal does not have all put the wrong letter on the wrong unit.

lodash passes the property name to _.forEach for objects, and the two configs are joined by that name everywhere else, so use it here too.