### PR TITLE
Modinfo date and GitHub link

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -42,5 +42,6 @@
     "enabled": true,
     "dependencies": [
         "com.pa.raevn.rfloatframe"
-    ]
+    ],
+    "github": "https://github.com/pietervanh/hotbuild2"
 }

--- a/modinfo.json
+++ b/modinfo.json
@@ -6,7 +6,7 @@
     "author": "proeleert, tripax, cola_colin",
     "version": "1.52",
     "build": "113578",
-    "date": "2019/10/19",
+    "date": "2019-10-19",
     "signature": " ",
     "forum": "https://forums.planetaryannihilation.com/threads/rel-cmm-hotbuild2-v1-50-113578.54561",
     "category": [


### PR DESCRIPTION
Changes the date to comply with ISO 8601, which is the requirement of PA's mod system. The current date format doesn't break anything, but in may in the future as it isn't to spec.

Also, introduces a link to the repo for people who wish to contribute.