### PR TITLE
Spec tag agnostic unit bindings

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -17,13 +17,16 @@
     "icon": "http://pamods.github.io/icons/hotbuild2.png",
     "scenes": {
         "live_game": [
+            "coui://ui/mods/hotbuild2/shared/hotbuild_specid.js",
             "coui://ui/mods/hotbuild2/live_game/hotbuild_core.js"
         ],
         "live_game_build_bar": [
+            "coui://ui/mods/hotbuild2/shared/hotbuild_specid.js",
             "coui://ui/mods/hotbuild2/live_game/hotbuild.css",
             "coui://ui/mods/hotbuild2/live_game/hotbuild_buildbar.js"
         ],
         "live_game_selection": [
+            "coui://ui/mods/hotbuild2/shared/hotbuild_specid.js",
             "coui://ui/mods/hotbuild2/live_game/hotbuild.css",
             "coui://ui/mods/hotbuild2/live_game/hotbuild_selection.js"
         ],
@@ -32,6 +35,7 @@
             "coui://ui/mods/hotbuild2/live_game/hotbuild_floatframe.js"
         ],
         "settings": [
+            "coui://ui/mods/hotbuild2/shared/hotbuild_specid.js",
             "coui://ui/mods/hotbuild2/settings/hotbuild_settings.css",
             "coui://ui/mods/hotbuild2/settings/hotbuild_settings.js"
         ],

--- a/modinfo.json
+++ b/modinfo.json
@@ -5,8 +5,8 @@
     "description": "Map 1 Key to multiple build actions and more... (See forum link for screenshots and instructions.)",
     "author": "proeleert, tripax, cola_colin",
     "version": "1.52",
-    "build": "113578",
-    "date": "2019/10/19",
+    "build": "124670",
+    "date": "2026/08/13",
     "signature": " ",
     "forum": "https://forums.planetaryannihilation.com/threads/rel-cmm-hotbuild2-v1-50-113578.54561",
     "category": [

--- a/ui/mods/hotbuild2/live_game/hotbuild_buildbar.js
+++ b/ui/mods/hotbuild2/live_game/hotbuild_buildbar.js
@@ -17,15 +17,11 @@ var hotbuild2buildbar = (function () {
     hbgetBuildBarKey = function (id) {
         var result = '';
         var hbpos = 1;
+        //the build bar hands us tagged ids in Galactic War, ours are stored untagged
+        var canonical = hbSpecId.canonical(id);
         _.forEach(hotbuildglobal, function (hbkey) {
             _.forEach(hbkey, function (hbitem) {
-                if (hbitem.json === id) {
-                    if (hotbuildglobalkey["hotbuild" + hbpos + "s"] !== undefined) {
-                        result += hotbuildglobalkey["hotbuild" + hbpos + "s"];
-                        return false;
-                    }
-                }
-                if (hbitem.json + ".player" === id) {
+                if (hbitem && hbSpecId.canonical(hbitem.json) === canonical) {
                     if (hotbuildglobalkey["hotbuild" + hbpos + "s"] !== undefined) {
                         result += hotbuildglobalkey["hotbuild" + hbpos + "s"];
                         return false;

--- a/ui/mods/hotbuild2/live_game/hotbuild_core.js
+++ b/ui/mods/hotbuild2/live_game/hotbuild_core.js
@@ -156,16 +156,20 @@ var hotbuild2 = (function () {
                 }
                 else {
                     if (self.selectionList().length > 0&&hotbuild_select_enable) { //check if units are selected ?
-                        var selectionTypes = [];
-                        for (var i = 0; i < self.hotbuilds().length; i++) {
-                            var typeindex = _.findIndex(self.selectionList(), { 'type': self.hotbuilds()[i].json });
-                            if (typeindex !== -1) {
-                                selectionTypes.push(self.hotbuilds()[i].json);
-                            }
+                        var i;
+                        var wanted = [];
+                        for (i = 0; i < self.hotbuilds().length; i++) {
+                            wanted.push(hbSpecId.canonical(self.hotbuilds()[i].json));
                         }
+                        //selectByTypes wants the tagged types the sim knows, so pass those back
+                        var selection = self.selectionList();
+                        var selectionTypes = [];
                         var currentselection = [];
-                        for (i = 0; i < self.selectionList().length; i++) {
-                            currentselection.push(self.selectionList()[i].type);
+                        for (i = 0; i < selection.length; i++) {
+                            currentselection.push(selection[i].type);
+                            if (_.contains(wanted, hbSpecId.canonical(selection[i].type))) {
+                                selectionTypes.push(selection[i].type);
+                            }
                         }
                         if (event.ctrlKey) {
                             if(selectionTypes.length > 0){

--- a/ui/mods/hotbuild2/live_game/hotbuild_core.js
+++ b/ui/mods/hotbuild2/live_game/hotbuild_core.js
@@ -66,34 +66,33 @@ var hotbuild2 = (function () {
         self.unitName = ko.observable("");
 
         self.buildPreviewList = function (hbindex, hotbuilds) {
-            //set the buildPreview list
-            if (hotbuilds !== undefined) {
-                self.hotbuildPreviews([{ 'icon': '', 'json': '' }]);
-                var unitinfo;
+            //set the buildPreview list, starting at the entry we just cycled to
+            if (hotbuilds === undefined) {
+                return;
+            }
+            //endFabMode parks cycleid at -1 when hotbuild_shift_key_recycle is ON
+            if (hbindex < 0 || hbindex > hotbuilds.length) {
+                hbindex = 0;
+            }
+            self.hotbuildPreviews([{ 'icon': '', 'json': '' }]);
 
-                for (var i = hbindex; i < hotbuilds.length; i++) {
-                    if (self.knowsBuildCommand(hotbuilds[i].json)) {
+            var order = [];
+            var i;
+            for (i = hbindex; i < hotbuilds.length; i++) {
+                order.push(i);
+            }
+            for (i = 0; i < hbindex; i++) {
+                order.push(i);
+            }
 
-                        unitinfo = model.unitSpecs[hotbuilds[i].json];
-                        if(unitinfo === undefined){
-                         unitinfo = model.unitSpecs[hotbuilds[i].json + ".player"];
-                        }
-                        if (unitinfo.structure) {
-                            console.log(unitinfo.buildIcon);
-                            self.hotbuildPreviews.push({ 'icon':  unitinfo.buildIcon, 'json': hotbuilds[i].json });
-                        }
-                    }
-                }
-                for (var j = 0; j < hbindex; j++) {
-                    if (self.knowsBuildCommand(hotbuilds[j].json)) {
-                        unitinfo = model.unitSpecs[hotbuilds[j].json];
-                        if(unitinfo === undefined){
-                         unitinfo = model.unitSpecs[hotbuilds[i].json + ".player"];
-                        }
-                        if (unitinfo.structure) {
-                            self.hotbuildPreviews.push({ 'icon':  unitinfo.buildIcon, 'json': hotbuilds[j].json });
-                        }
-                    }
+            for (i = 0; i < order.length; i++) {
+                var stored = hotbuilds[order[i]].json;
+                var unitinfo = self.findBuildable(stored);
+                if (unitinfo !== undefined && unitinfo.structure) {
+                    self.hotbuildPreviews.push({
+                        'icon': unitinfo.buildIcon || hbSpecId.buildBarIcon(unitinfo.id),
+                        'json': hbSpecId.canonical(stored)
+                    });
                 }
             }
         };
@@ -126,9 +125,11 @@ var hotbuild2 = (function () {
                     setTimeout(self.clean, self.cycleResetTime + 1000);
                     //debugger;
 
-                    var hbunit = model.unitSpecs[self.hotbuilds()[self.cycleid()].json];
-                    if(hbunit === undefined){
-                        hbunit = model.unitSpecs[self.hotbuilds()[self.cycleid()].json + ".player"];
+                    //the build set carries this client's spec tag, so its id is the one the sim knows
+                    var hbunit = self.findBuildable(self.hotbuilds()[self.cycleid()].json);
+                    if (hbunit === undefined) {
+                        console.log("hotbuild cannot build " + self.hotbuilds()[self.cycleid()].json);
+                        return;
                     }
 
                     if (hbunit.structure) {
@@ -193,22 +194,13 @@ var hotbuild2 = (function () {
             return false;
         };
 
-        self.knowsBuildCommand = function (cmd) {
-            //check on buildtablist empty
-            if(self.buildable_units().length > 0){
-                for(var i = 0; i < self.buildable_units().length; i++){
-                    if(self.buildable_units()[i].id == cmd) {
-                        //console.log("can build " +self.buildable_units()[i].id);
-                        return true;
-                    }
-                    //GW fix
-                    if(self.buildable_units()[i].id == cmd + ".player") {
-                        return true;
-                    }
-                }
-            }
+        //the live spec for a stored hotbuild entry, whatever spec tag this game uses
+        self.findBuildable = function (cmd) {
+            return hbSpecId.findSpec(self.buildable_units(), cmd);
+        };
 
-            return false;
+        self.knowsBuildCommand = function (cmd) {
+            return self.findBuildable(cmd) !== undefined;
         };
 
         //move trough hotbuilds array when pushing multiple time the same key in a certain time interval

--- a/ui/mods/hotbuild2/live_game/hotbuild_selection.js
+++ b/ui/mods/hotbuild2/live_game/hotbuild_selection.js
@@ -17,15 +17,11 @@ var hotbuild2selection = (function () {
     hbgetBuildBarKey = function (id) {
         var result = '';
         var hbpos = 1;
+        //the selection hands us tagged ids in Galactic War, ours are stored untagged
+        var canonical = hbSpecId.canonical(id);
         _.forEach(hotbuildglobal, function (hbkey) {
             _.forEach(hbkey, function (hbitem) {
-                if (hbitem.json === id) {
-                    if (hotbuildglobalkey["hotbuild" + hbpos + "s"] !== undefined) {
-                        result += hotbuildglobalkey["hotbuild" + hbpos + "s"];
-                        return false;
-                    }
-                }
-                if (hbitem.json + ".player" === id) {
+                if (hbitem && hbSpecId.canonical(hbitem.json) === canonical) {
                     if (hotbuildglobalkey["hotbuild" + hbpos + "s"] !== undefined) {
                         result += hotbuildglobalkey["hotbuild" + hbpos + "s"];
                         return false;

--- a/ui/mods/hotbuild2/settings/hotbuild_settings.css
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.css
@@ -387,6 +387,11 @@ text-align: center;
 margin-right: -64px !important;
 }
 
+/* bound to a unit this game has no spec for, kept but unusable here */
+.hotbuild_list_item.hb_missing {
+	opacity: 0.4;
+}
+
 .hotbuild_list_item:hover, .hotbuild_list_item:active {
 	-webkit-filter: drop-shadow(0px 0px 4px rgba(255,255,255,1));
 }

--- a/ui/mods/hotbuild2/settings/hotbuild_settings.html
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.html
@@ -140,7 +140,7 @@
 
 
 
-<script id="leftTemplate" type="text/html"><div class="hotbuild_list_item">
+<script id="leftTemplate" type="text/html"><div class="hotbuild_list_item" data-bind="css: { hb_missing: hbmissing }">
         <div class="hotbuild_fab_selection">
             <span class="hotbuild_selected_text" data-bind="text: $index() + 1"></span>
             <img class="hotbuild_selected_fab" src="" data-bind="attr: { src: image }" alt="hbpreview">

--- a/ui/mods/hotbuild2/settings/hotbuild_settings.js
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.js
@@ -8,6 +8,8 @@ var hotbuildsettings = (function () {
 
     function HotBuildSettingsViewModel(hbglobal, hbglobalkey) {
         var self = this;
+        //migrate configs written before ids were stored untagged
+        hbSpecId.normaliseConfig(hbglobal);
         self.hotbuilddirty = ko.observable(false);
         self.hotbuildglobal = ko.observable(hbglobal).extend({ notify: 'always' });
         self.hotbuildglobalkey = ko.observable(hbglobalkey);
@@ -206,7 +208,11 @@ var hotbuildsettings = (function () {
                 viewmodelconfigkey['hotbuild' + nr + 's'] = copyconfigkey[hotkey];
                 viewmodelconfig['hotbuild' + nr + 's'] = [];
                 for (var i = 0; i < copyconfig[hotkey].length; i++) {
-                    viewmodelconfig['hotbuild' + nr + 's'].push({ 'json': copyconfig[hotkey][i].json });
+                    if (!copyconfig[hotkey][i] || !copyconfig[hotkey][i].json) {
+                        continue;
+                    }
+                    //store untagged so one mapping works under every spec tag
+                    viewmodelconfig['hotbuild' + nr + 's'].push({ 'json': hbSpecId.canonical(copyconfig[hotkey][i].json) });
                 }
                 nr++;
             }
@@ -326,7 +332,8 @@ var hotbuildsettings = (function () {
             self.keyboardkey('');
             console.log('HOTBUILD2 IMPORTING KEY CONFIG------------');
             self.hotbuildglobalkey(imported.hotbuildglobalkey);
-            self.hotbuildglobal(imported.hotbuildglobal);
+            //a .pas exported from a Galactic War session can hold tagged ids
+            self.hotbuildglobal(hbSpecId.normaliseConfig(imported.hotbuildglobal));
             updateExistingSettings();
             self.Save();
             console.log('WROTE HOTBUILD KEYS-----------');

--- a/ui/mods/hotbuild2/settings/hotbuild_settings.js
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.js
@@ -13,8 +13,10 @@ var hotbuildsettings = (function () {
         self.hotbuilddirty = ko.observable(false);
         self.hotbuildglobal = ko.observable(hbglobal).extend({ notify: 'always' });
         self.hotbuildglobalkey = ko.observable(hbglobalkey);
-        self.cleanhotbuildglobal = ko.observable(hbglobal);
-        self.cleanhotbuildglobalkey = ko.observable(hbglobalkey);
+        //copies, not the same objects: updateExistingSettings prunes hotbuildglobal in
+        //place and hotbuildStore writes these on any Save, hotbuild edit or not
+        self.cleanhotbuildglobal = ko.observable(_.cloneDeep(hbglobal));
+        self.cleanhotbuildglobalkey = ko.observable(_.cloneDeep(hbglobalkey));
         self.selectedhotbuild = ko.observableArray([]);
         self.filteredunits = ko.observableArray([]);
         self.units = ko.observableArray([]);
@@ -47,6 +49,10 @@ var hotbuildsettings = (function () {
         });
 
         function updateExistingSettings() {
+            //nothing to compare against yet, don't prune the config to nothing
+            if (self.units().length === 0) {
+                return;
+            }
             //now compare / update the existing hotbuildglobal data so it's always up 2 date
             for (var hbkey in self.hotbuildglobal()) {
                 //if(_.contains(self.units(),hb.json))

--- a/ui/mods/hotbuild2/settings/hotbuild_settings.js
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.js
@@ -21,32 +21,93 @@ var hotbuildsettings = (function () {
         self.filteredunits = ko.observableArray([]);
         self.units = ko.observableArray([]);
 
-        model.unitSpecs.subscribe(function (unitspecs) {
-            
-            if (unitspecs)
-            {
-                var filteredresults = [];
-                Object.keys(unitspecs).forEach(function(key,index) {
-                    //don't show commanders and debug units
-                    var unit = unitspecs[key];
-                    if (!_.contains(unit.types, 'UNITTYPE_Commander') && !_.contains(unit.types, 'UNITTYPE_Debug') && !_.contains(unit.types, 'UNITTYPE_NoBuild') ) {
-                        //console.log(unit);
-                        var hotbuildunit = {
-                            json: unit.id,
-                            displayname: loc(unit.name),
-                            desc: loc(unit.description),
-                            image: 'coui:/' + unit.id.replace('.json','_icon_buildbar.png'),
-                            types: unit.types,
-                            structure: unit.structure
-                        };
+        //in a Galactic War game the sim has a copy of every unit per spec tag, so the
+        //picker has to pick one of them to show. lower rank wins, cosmetic only.
+        self.hbSpecTag = null;
+        function hbTagRank(tag) {
+            if (self.hbSpecTag && tag === self.hbSpecTag) {
+                return 0;
+            }
+            if (tag === '') {
+                return 1;
+            }
+            if (tag === '.player') {
+                return 2;
+            }
+            return 3;
+        }
+
+        var hbUnitSpecs = null;
+        var hbFirstBuild = true;
+
+        self.hbBuildUnitList = function () {
+            if (!hbUnitSpecs) {
+                return;
+            }
+            var filteredresults = [];
+            var seen = {};
+            Object.keys(hbUnitSpecs).forEach(function(key,index) {
+                //don't show commanders and debug units
+                var unit = hbUnitSpecs[key];
+                if (unit && !_.contains(unit.types, 'UNITTYPE_Commander') && !_.contains(unit.types, 'UNITTYPE_Debug') && !_.contains(unit.types, 'UNITTYPE_NoBuild') ) {
+                    //console.log(unit);
+                    //the key is the spec id, unit.id is only set by crossRef in the live game scenes
+                    var canonical = hbSpecId.canonical(key);
+                    var rank = hbTagRank(hbSpecId.tag(key));
+                    var existing = seen[canonical];
+                    if (existing !== undefined && rank >= filteredresults[existing].hbrank) {
+                        return;
+                    }
+                    var hotbuildunit = {
+                        json: canonical,
+                        displayname: loc(unit.name),
+                        desc: loc(unit.description),
+                        image: hbSpecId.buildBarIcon(canonical),
+                        types: unit.types,
+                        structure: unit.structure,
+                        hbrank: rank
+                    };
+                    if (existing === undefined) {
+                        seen[canonical] = filteredresults.length;
                         filteredresults.push(hotbuildunit);
                     }
-                });
-                self.units(filteredresults);
+                    else {
+                        filteredresults[existing] = hotbuildunit;
+                    }
+                }
+            });
+            self.units(filteredresults);
+            if (hbFirstBuild) {
+                hbFirstBuild = false;
                 self.filteredunits(_.filter(filteredresults, function(u){ return u.structure; })); //set standard on all buildings
-                updateExistingSettings(); 
-            }                             
+            }
+            else {
+                self.filterunits(); //rebuilt underneath the user, keep them on their filter
+            }
+            updateExistingSettings();
+        };
+
+        model.unitSpecs.subscribe(function (unitspecs) {
+            if (unitspecs)
+            {
+                hbUnitSpecs = unitspecs;
+                self.hbBuildUnitList();
+            }
         });
+
+        //never gate the picker on this, it may never resolve outside a game
+        try {
+            var hbTagRequest = api.game.getUnitSpecTag();
+            if (hbTagRequest && _.isFunction(hbTagRequest.then)) {
+                hbTagRequest.then(function (tag) {
+                    self.hbSpecTag = tag || '';
+                    self.hbBuildUnitList();
+                });
+            }
+        }
+        catch (ex) {
+            console.log(ex);
+        }
 
         function updateExistingSettings() {
             //nothing to compare against yet, don't prune the config to nothing

--- a/ui/mods/hotbuild2/settings/hotbuild_settings.js
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.js
@@ -109,6 +109,20 @@ var hotbuildsettings = (function () {
             console.log(ex);
         }
 
+        //a binding this spec set has no unit for, e.g. a Legion unit in a vanilla game.
+        //shown greyed and kept, so it survives back into localStorage on the next save.
+        function hbMissingUnit(json) {
+            return {
+                json: json,
+                displayname: json.replace(/^.*\//, '').replace(/\.json$/, ''),
+                desc: 'NOT AVAILABLE HERE',
+                image: hbSpecId.buildBarIcon(json),
+                types: [],
+                structure: false,
+                hbmissing: true
+            };
+        }
+
         function updateExistingSettings() {
             //nothing to compare against yet, don't prune the config to nothing
             if (self.units().length === 0) {
@@ -116,16 +130,15 @@ var hotbuildsettings = (function () {
             }
             //now compare / update the existing hotbuildglobal data so it's always up 2 date
             for (var hbkey in self.hotbuildglobal()) {
-                //if(_.contains(self.units(),hb.json))
-                for (var i = 0; i < self.hotbuildglobal()[hbkey].length; i++) {
-                    var match = _.find(self.units(), { 'json': self.hotbuildglobal()[hbkey][i].json });
-                    self.hotbuildglobal()[hbkey][i] = match;
-                }
+                var entries = self.hotbuildglobal()[hbkey];
                 var goodstuff = [];
-                for (i = 0; i < self.hotbuildglobal()[hbkey].length; i++) {
-                    if (self.hotbuildglobal()[hbkey][i] !== undefined) {
-                        goodstuff.push(self.hotbuildglobal()[hbkey][i]);
+                for (var i = 0; i < entries.length; i++) {
+                    if (!entries[i] || !entries[i].json) {
+                        continue;
                     }
+                    var json = hbSpecId.canonical(entries[i].json);
+                    var match = _.find(self.units(), { 'json': json });
+                    goodstuff.push(match !== undefined ? match : hbMissingUnit(json));
                 }
                 self.hotbuildglobal()[hbkey] = goodstuff;
             }

--- a/ui/mods/hotbuild2/shared/hotbuild_specid.js
+++ b/ui/mods/hotbuild2/shared/hotbuild_specid.js
@@ -1,0 +1,75 @@
+console.log("loading hotbuild2 spec id helper");
+
+var hbSpecId = (function () {
+
+    //same expressions stock PA uses: build.js and live_game_build_bar.js
+    var CANONICAL = /(.*\.json)[^\/]*$/;
+    var NOEXTENSION = /(.*)\.json[^\/]*$/;
+    var MISSING_ICON = 'coui://ui/main/game/live_game/img/build_bar/img_missing_unit.png';
+
+    var specid = {};
+
+    //'/pa/x/y.json.player1' -> '/pa/x/y.json' , untagged ids pass through
+    specid.canonical = function (id) {
+        if (!id) {
+            return id;
+        }
+        var match = CANONICAL.exec(id);
+        return (match && match[1]) ? match[1] : id;
+    };
+
+    //'/pa/x/y.json.player1' -> '.player1' , untagged ids give ''
+    specid.tag = function (id) {
+        if (!id) {
+            return '';
+        }
+        var canon = specid.canonical(id);
+        return (id.length > canon.length) ? id.slice(canon.length) : '';
+    };
+
+    specid.same = function (a, b) {
+        return specid.canonical(a) === specid.canonical(b);
+    };
+
+    //the settings scene has no Build global, build.js isn't in settings.html
+    specid.buildBarIcon = function (id) {
+        var match = id ? NOEXTENSION.exec(id) : null;
+        if (!match || !match[1]) {
+            return MISSING_ICON;
+        }
+        return 'coui:/' + match[1] + '_icon_buildbar.png';
+    };
+
+    //first entry of list whose .id is the same unit, whatever tag either carries
+    specid.findSpec = function (list, id) {
+        var canon = specid.canonical(id);
+        var count = list ? list.length : 0;
+        for (var i = 0; i < count; i++) {
+            if (list[i] && specid.canonical(list[i].id) === canon) {
+                return list[i];
+            }
+        }
+        return undefined;
+    };
+
+    //in place, never adds/removes/reorders hotbuildNs keys
+    specid.normaliseConfig = function (config) {
+        for (var hotkey in config) {
+            var entries = config[hotkey];
+            if (!entries || entries.length === undefined) {
+                continue;
+            }
+            for (var i = 0; i < entries.length; i++) {
+                if (entries[i] && entries[i].json) {
+                    entries[i].json = specid.canonical(entries[i].json);
+                }
+            }
+        }
+        return config;
+    };
+
+    return specid;
+
+})();
+
+console.log("loaded hotbuild2 spec id helper");


### PR DESCRIPTION
## The problem

Galactic War doesn't run units off the shared `/pa/units/**` specs. The referee mounts a per-army copy of every spec into an in-memory filesystem, keyed by the file path plus a **spec tag** — so the same unit is `…/tank.json.player` for one army and `…/tank.json.ai0` for another. Outside GW there's no tag at all. Galactic War's per-player-tech co-op widens it further: the host keeps `.player` and every additional client gets `.player0`, `.player1`, … `.playerN`, bounded only by the lobby size.

hotbuild2 stores bindings untagged and retries each comparison once with `".player"` appended — six sites across four files. That covers solo GW and nothing else:

- A co-op client on `.player1` gets no key letters on the build bar, `knowsBuildCommand` returns false for everything, and `model.unitSpecs[… + ".player"]` is `undefined`, so the next line throws reading `.structure`.
- Hot-select has no tag handling at all — it compares an untagged stored id against `selectionList()[].type`, which the sim always reports tagged. It is dead in *every* GW game, `.player` included.
- Opening the configurator from inside a GW battle is destructive. `updateExistingSettings` matches untagged stored ids against tagged picker ids, finds nothing, and empties every list in place — and because `cleanhotbuildglobal` was the *same object* as`hotbuildglobal`, a plain Save persisted the result. Change your UI scale in a GW game and the whole config is gone.
- The picker listed every unit once per mounted tag, so in GW you scrolled past several copies of each.

## The change

Normalise to the canonical untagged id on **both sides of every comparison**, using the same regex stock PA uses (`shared/js/build.js`, `live_game_build_bar.js`), rather than appending any particular tag. That's a new `hbSpecId` helper, registered first in the four scene arrays that need it — `loadScript` is a synchronous XHR and `loadMods` walks the array in order, so it's always defined before the scripts that use it. It's a shared file rather than a fifth copy-paste because it *is* the matching rule: a drift between two copies would read as "the key label renders but pressing it does nothing", in GW only. The settings scene needs it as a file regardless, since `build.js` isn't in `settings.html`.

The rule the rest of the change follows: **anything handed to the engine is a live id taken from live data.** `buildItemBySpec`, `executeStartBuild` and `selectByTypes` all want the tagged id the sim knows, so it now comes from `buildable_units()` (the build bar's `selectedSpecs()`, which always carries this client's tag and already has `id`/`name`/`structure`/`buildIcon`) or from `selectionList()[].type`. Never a canonical id, and never one rebuilt from `api.game.getUnitSpecTag()` — that can return `.player` for a client whose real tag is `.playerN`, so it's used only as a display hint.

Three things fixed in passing, all on code the change was already rewriting:

- `buildPreviewList`'s second loop indexed `hotbuilds[i]` where the loop variable was `j`, so it threw the moment the untagged lookup missed — i.e. exactly in GW.
- `hotBuild` threw on `undefined.structure` whenever the cycle ended on something unbuildable; it now logs and bails.
- Hot-select used `_.findIndex`, which finds one match, so a key bound to two selected unit types only ever filtered on one.

`e8c6b3d` and `4be9300` are both "settings must stop eating your config". The first is squarely spec-tag work — the emptying was *caused* by the tag mismatch. The second is adjacent rather than caused by it: its trigger is "this spec set has no unit with that id", which also fires outside GW when a faction mod is disabled. It's here because it lives in the same function and depends on the new helper; happy to split it if you'd rather.

## Testing

Ran against PA 124670 in Skirmish, solo Galactic War, co-op shared tech GW, and co-op separate tech GW.