### PR TITLE
Scan faction units without a `live_game`

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -17,13 +17,16 @@
     "icon": "http://pamods.github.io/icons/hotbuild2.png",
     "scenes": {
         "live_game": [
+            "coui://ui/mods/hotbuild2/shared/hotbuild_specid.js",
             "coui://ui/mods/hotbuild2/live_game/hotbuild_core.js"
         ],
         "live_game_build_bar": [
+            "coui://ui/mods/hotbuild2/shared/hotbuild_specid.js",
             "coui://ui/mods/hotbuild2/live_game/hotbuild.css",
             "coui://ui/mods/hotbuild2/live_game/hotbuild_buildbar.js"
         ],
         "live_game_selection": [
+            "coui://ui/mods/hotbuild2/shared/hotbuild_specid.js",
             "coui://ui/mods/hotbuild2/live_game/hotbuild.css",
             "coui://ui/mods/hotbuild2/live_game/hotbuild_selection.js"
         ],
@@ -32,6 +35,7 @@
             "coui://ui/mods/hotbuild2/live_game/hotbuild_floatframe.js"
         ],
         "settings": [
+            "coui://ui/mods/hotbuild2/shared/hotbuild_specid.js",
             "coui://ui/mods/hotbuild2/settings/hotbuild_settings.css",
             "coui://ui/mods/hotbuild2/settings/hotbuild_settings.js"
         ],

--- a/modinfo.json
+++ b/modinfo.json
@@ -18,6 +18,7 @@
     "scenes": {
         "live_game": [
             "coui://ui/mods/hotbuild2/shared/hotbuild_specid.js",
+            "coui://ui/mods/hotbuild2/shared/hotbuild_unitcache.js",
             "coui://ui/mods/hotbuild2/live_game/hotbuild_core.js"
         ],
         "live_game_build_bar": [
@@ -36,6 +37,8 @@
         ],
         "settings": [
             "coui://ui/mods/hotbuild2/shared/hotbuild_specid.js",
+            "coui://ui/mods/hotbuild2/shared/hotbuild_unitcache.js",
+            "coui://ui/mods/hotbuild2/settings/hotbuild_modscan.js",
             "coui://ui/mods/hotbuild2/settings/hotbuild_settings.css",
             "coui://ui/mods/hotbuild2/settings/hotbuild_settings.js"
         ],

--- a/modinfo.json
+++ b/modinfo.json
@@ -5,8 +5,8 @@
     "description": "Map 1 Key to multiple build actions and more... (See forum link for screenshots and instructions.)",
     "author": "proeleert, tripax, cola_colin",
     "version": "1.52",
-    "build": "113578",
-    "date": "2019/10/19",
+    "build": "124670",
+    "date": "2026/08/13",
     "signature": " ",
     "forum": "https://forums.planetaryannihilation.com/threads/rel-cmm-hotbuild2-v1-50-113578.54561",
     "category": [

--- a/ui/mods/hotbuild2/live_game/hotbuild_buildbar.js
+++ b/ui/mods/hotbuild2/live_game/hotbuild_buildbar.js
@@ -17,15 +17,11 @@ var hotbuild2buildbar = (function () {
     hbgetBuildBarKey = function (id) {
         var result = '';
         var hbpos = 1;
+        //the build bar hands us tagged ids in Galactic War, ours are stored untagged
+        var canonical = hbSpecId.canonical(id);
         _.forEach(hotbuildglobal, function (hbkey) {
             _.forEach(hbkey, function (hbitem) {
-                if (hbitem.json === id) {
-                    if (hotbuildglobalkey["hotbuild" + hbpos + "s"] !== undefined) {
-                        result += hotbuildglobalkey["hotbuild" + hbpos + "s"];
-                        return false;
-                    }
-                }
-                if (hbitem.json + ".player" === id) {
+                if (hbitem && hbSpecId.canonical(hbitem.json) === canonical) {
                     if (hotbuildglobalkey["hotbuild" + hbpos + "s"] !== undefined) {
                         result += hotbuildglobalkey["hotbuild" + hbpos + "s"];
                         return false;

--- a/ui/mods/hotbuild2/live_game/hotbuild_core.js
+++ b/ui/mods/hotbuild2/live_game/hotbuild_core.js
@@ -156,16 +156,20 @@ var hotbuild2 = (function () {
                 }
                 else {
                     if (self.selectionList().length > 0&&hotbuild_select_enable) { //check if units are selected ?
-                        var selectionTypes = [];
-                        for (var i = 0; i < self.hotbuilds().length; i++) {
-                            var typeindex = _.findIndex(self.selectionList(), { 'type': self.hotbuilds()[i].json });
-                            if (typeindex !== -1) {
-                                selectionTypes.push(self.hotbuilds()[i].json);
-                            }
+                        var i;
+                        var wanted = [];
+                        for (i = 0; i < self.hotbuilds().length; i++) {
+                            wanted.push(hbSpecId.canonical(self.hotbuilds()[i].json));
                         }
+                        //selectByTypes wants the tagged types the sim knows, so pass those back
+                        var selection = self.selectionList();
+                        var selectionTypes = [];
                         var currentselection = [];
-                        for (i = 0; i < self.selectionList().length; i++) {
-                            currentselection.push(self.selectionList()[i].type);
+                        for (i = 0; i < selection.length; i++) {
+                            currentselection.push(selection[i].type);
+                            if (_.contains(wanted, hbSpecId.canonical(selection[i].type))) {
+                                selectionTypes.push(selection[i].type);
+                            }
                         }
                         if (event.ctrlKey) {
                             if(selectionTypes.length > 0){

--- a/ui/mods/hotbuild2/live_game/hotbuild_core.js
+++ b/ui/mods/hotbuild2/live_game/hotbuild_core.js
@@ -14,6 +14,22 @@ var hotbuild2 = (function () {
     var hotbuildshiftrecycle = api.settings.isSet('ui','hotbuild_shift_key_recycle',true) || "OFF";
     var hotbuildreset_time = api.settings.isSet('ui','hotbuild_reset_time',true) || 2000;
 
+    //remember the sim's spec set. it is the only place a server mod's units show up, and
+    //the settings scene has no way to see them once the game is over.
+    if(_.isFunction(handlers.unit_specs))
+    {
+        var hotbuild2oldunitspecs = handlers.unit_specs;
+        handlers.unit_specs = function(payload){
+          hotbuild2oldunitspecs(payload);
+          try {
+            hbUnitCache.harvest(payload);
+          }
+          catch (ex) {
+            console.log(ex);
+          }
+        };
+    }
+
     //handle settings refresh
     if(_.isFunction(handlers['settings.exit']))
     {

--- a/ui/mods/hotbuild2/live_game/hotbuild_core.js
+++ b/ui/mods/hotbuild2/live_game/hotbuild_core.js
@@ -66,34 +66,33 @@ var hotbuild2 = (function () {
         self.unitName = ko.observable("");
 
         self.buildPreviewList = function (hbindex, hotbuilds) {
-            //set the buildPreview list
-            if (hotbuilds !== undefined) {
-                self.hotbuildPreviews([{ 'icon': '', 'json': '' }]);
-                var unitinfo;
+            //set the buildPreview list, starting at the entry we just cycled to
+            if (hotbuilds === undefined) {
+                return;
+            }
+            //endFabMode parks cycleid at -1 when hotbuild_shift_key_recycle is ON
+            if (hbindex < 0 || hbindex > hotbuilds.length) {
+                hbindex = 0;
+            }
+            self.hotbuildPreviews([{ 'icon': '', 'json': '' }]);
 
-                for (var i = hbindex; i < hotbuilds.length; i++) {
-                    if (self.knowsBuildCommand(hotbuilds[i].json)) {
+            var order = [];
+            var i;
+            for (i = hbindex; i < hotbuilds.length; i++) {
+                order.push(i);
+            }
+            for (i = 0; i < hbindex; i++) {
+                order.push(i);
+            }
 
-                        unitinfo = model.unitSpecs[hotbuilds[i].json];
-                        if(unitinfo === undefined){
-                         unitinfo = model.unitSpecs[hotbuilds[i].json + ".player"];
-                        }
-                        if (unitinfo.structure) {
-                            console.log(unitinfo.buildIcon);
-                            self.hotbuildPreviews.push({ 'icon':  unitinfo.buildIcon, 'json': hotbuilds[i].json });
-                        }
-                    }
-                }
-                for (var j = 0; j < hbindex; j++) {
-                    if (self.knowsBuildCommand(hotbuilds[j].json)) {
-                        unitinfo = model.unitSpecs[hotbuilds[j].json];
-                        if(unitinfo === undefined){
-                         unitinfo = model.unitSpecs[hotbuilds[i].json + ".player"];
-                        }
-                        if (unitinfo.structure) {
-                            self.hotbuildPreviews.push({ 'icon':  unitinfo.buildIcon, 'json': hotbuilds[j].json });
-                        }
-                    }
+            for (i = 0; i < order.length; i++) {
+                var stored = hotbuilds[order[i]].json;
+                var unitinfo = self.findBuildable(stored);
+                if (unitinfo !== undefined && unitinfo.structure) {
+                    self.hotbuildPreviews.push({
+                        'icon': unitinfo.buildIcon || hbSpecId.buildBarIcon(unitinfo.id),
+                        'json': hbSpecId.canonical(stored)
+                    });
                 }
             }
         };
@@ -126,9 +125,11 @@ var hotbuild2 = (function () {
                     setTimeout(self.clean, self.cycleResetTime + 1000);
                     //debugger;
 
-                    var hbunit = model.unitSpecs[self.hotbuilds()[self.cycleid()].json];
-                    if(hbunit === undefined){
-                        hbunit = model.unitSpecs[self.hotbuilds()[self.cycleid()].json + ".player"];
+                    //the build set carries this client's spec tag, so its id is the one the sim knows
+                    var hbunit = self.findBuildable(self.hotbuilds()[self.cycleid()].json);
+                    if (hbunit === undefined) {
+                        console.log("hotbuild cannot build " + self.hotbuilds()[self.cycleid()].json);
+                        return;
                     }
 
                     if (hbunit.structure) {
@@ -193,22 +194,13 @@ var hotbuild2 = (function () {
             return false;
         };
 
-        self.knowsBuildCommand = function (cmd) {
-            //check on buildtablist empty
-            if(self.buildable_units().length > 0){
-                for(var i = 0; i < self.buildable_units().length; i++){
-                    if(self.buildable_units()[i].id == cmd) {
-                        //console.log("can build " +self.buildable_units()[i].id);
-                        return true;
-                    }
-                    //GW fix
-                    if(self.buildable_units()[i].id == cmd + ".player") {
-                        return true;
-                    }
-                }
-            }
+        //the live spec for a stored hotbuild entry, whatever spec tag this game uses
+        self.findBuildable = function (cmd) {
+            return hbSpecId.findSpec(self.buildable_units(), cmd);
+        };
 
-            return false;
+        self.knowsBuildCommand = function (cmd) {
+            return self.findBuildable(cmd) !== undefined;
         };
 
         //move trough hotbuilds array when pushing multiple time the same key in a certain time interval

--- a/ui/mods/hotbuild2/live_game/hotbuild_selection.js
+++ b/ui/mods/hotbuild2/live_game/hotbuild_selection.js
@@ -17,15 +17,11 @@ var hotbuild2selection = (function () {
     hbgetBuildBarKey = function (id) {
         var result = '';
         var hbpos = 1;
+        //the selection hands us tagged ids in Galactic War, ours are stored untagged
+        var canonical = hbSpecId.canonical(id);
         _.forEach(hotbuildglobal, function (hbkey) {
             _.forEach(hbkey, function (hbitem) {
-                if (hbitem.json === id) {
-                    if (hotbuildglobalkey["hotbuild" + hbpos + "s"] !== undefined) {
-                        result += hotbuildglobalkey["hotbuild" + hbpos + "s"];
-                        return false;
-                    }
-                }
-                if (hbitem.json + ".player" === id) {
+                if (hbitem && hbSpecId.canonical(hbitem.json) === canonical) {
                     if (hotbuildglobalkey["hotbuild" + hbpos + "s"] !== undefined) {
                         result += hotbuildglobalkey["hotbuild" + hbpos + "s"];
                         return false;

--- a/ui/mods/hotbuild2/settings/hotbuild_modscan.js
+++ b/ui/mods/hotbuild2/settings/hotbuild_modscan.js
@@ -1,0 +1,338 @@
+console.log("loading hotbuild2 mod scan");
+
+//Units a server mod adds are not in the client's file system outside a game: the engine
+//builds its spec set from what the client has mounted, and a server mod's specs are only
+//mounted into the server. This reads them straight off the enabled server mods instead.
+var hbModScan = (function () {
+
+    var MODS_DB = 'installed_mods';
+    var SERVER_MODS = '/server_mods/';
+    var UNIT_LIST = 'pa/units/unit_list.json';
+    var BASE_SPEC_HOPS = 2;
+
+    //mounted memory files answer to spec:, not to coui:
+    function specUrl(base, path) {
+        return 'spec:' + base + path.substr(1);
+    }
+
+    function stockSpecUrl(path) {
+        return 'spec:/' + path;
+    }
+
+    //the community mods manager keeps every installed mod in one record, so this is the
+    //only place that knows which server mods are enabled while no server is running
+    function readInstalledMods() {
+        var deferred = $.Deferred();
+        var request;
+
+        try {
+            request = indexedDB.open(MODS_DB);
+        }
+        catch (ex) {
+            console.log(ex);
+            deferred.resolve([]);
+            return deferred;
+        }
+
+        var creating = false;
+        //no community mods manager: opening made the db, so put it back
+        request.onupgradeneeded = function () {
+            creating = true;
+        };
+        request.onerror = function () {
+            deferred.resolve([]);
+        };
+        request.onsuccess = function (event) {
+            var db = event.target.result;
+            if (creating || !db.objectStoreNames.contains(MODS_DB)) {
+                db.close();
+                indexedDB.deleteDatabase(MODS_DB);
+                deferred.resolve([]);
+                return;
+            }
+            var mods = [];
+            try {
+                var cursor = db.transaction(MODS_DB, 'readonly').objectStore(MODS_DB).openCursor();
+                cursor.onsuccess = function (ev) {
+                    var entry = ev.target.result;
+                    if (entry) {
+                        if (entry.value && _.isArray(entry.value.value)) {
+                            mods = mods.concat(entry.value.value);
+                        }
+                        entry.continue();
+                        return;
+                    }
+                    db.close();
+                    deferred.resolve(mods);
+                };
+                cursor.onerror = function () {
+                    db.close();
+                    deferred.resolve([]);
+                };
+            }
+            catch (ex) {
+                console.log(ex);
+                db.close();
+                deferred.resolve([]);
+            }
+        };
+
+        return deferred;
+    }
+
+    //a mod the manager tracks. unitList is only set for mods shipping a unit list, so
+    //ai, biome and map mods are dropped before anything is mounted.
+    function trackedCandidates(mods) {
+        var candidates = [];
+        _.forEach(mods, function (mod) {
+            if (!mod || mod.context !== 'server' || !mod.enabled || !mod.unitList) {
+                return;
+            }
+            var installedPath = mod.installedPath || '';
+            candidates.push({
+                identifier: mod.identifier,
+                version: mod.version,
+                base: mod.mountPath || (SERVER_MODS + mod.identifier + '/'),
+                zip: installedPath.slice(-4) === '.zip' ? installedPath : false
+            });
+        });
+        return candidates;
+    }
+
+    //a loose directory under server_mods, i.e. installed by hand or by PAMM rather than
+    //by the manager. api.file.list gives a coherent promise, so no done/fail here.
+    function looseCandidates(taken) {
+        var deferred = $.Deferred();
+
+        api.file.list(SERVER_MODS, false).then(function (listing) {
+            if (!_.isArray(listing)) {
+                deferred.resolve([]);
+                return;
+            }
+            //a mounted zip comes back without the trailing slash a real directory has
+            var dirs = _.filter(listing, function (path) {
+                return path.slice(-1) === '/';
+            });
+            if (!dirs.length) {
+                deferred.resolve([]);
+                return;
+            }
+
+            var candidates = [];
+            var outstanding = dirs.length;
+            var finished = function () {
+                outstanding = outstanding - 1;
+                if (outstanding === 0) {
+                    deferred.resolve(candidates);
+                }
+            };
+
+            _.forEach(dirs, function (dir) {
+                $.getJSON('coui:' + dir + 'modinfo.json').done(function (modinfo) {
+                    if (modinfo && modinfo.context !== 'client' && !taken[modinfo.identifier]) {
+                        candidates.push({
+                            identifier: modinfo.identifier,
+                            version: modinfo.version,
+                            base: dir,
+                            zip: false
+                        });
+                    }
+                    finished();
+                }).fail(finished);
+            });
+        }, function () {
+            deferred.resolve([]);
+        });
+
+        return deferred;
+    }
+
+    function discover() {
+        var deferred = $.Deferred();
+
+        readInstalledMods().always(function (mods) {
+            var candidates = trackedCandidates(_.isArray(mods) ? mods : []);
+            var taken = {};
+            _.forEach(candidates, function (candidate) {
+                taken[candidate.identifier] = true;
+            });
+            looseCandidates(taken).always(function (loose) {
+                deferred.resolve(candidates.concat(_.isArray(loose) ? loose : []));
+            });
+        });
+
+        return deferred;
+    }
+
+    function signatureOf(candidates) {
+        return _.map(candidates, function (candidate) {
+            return candidate.identifier + '@' + candidate.version;
+        }).sort().join(';');
+    }
+
+    function parse(data) {
+        return _.isString(data) ? JSON.parse(data) : data;
+    }
+
+    //read the mod's unit list, mounting its archive only if it is not readable already.
+    //in a game the manager has usually mounted it, and that mount is the expensive part.
+    function readUnitList(candidate) {
+        var deferred = $.Deferred();
+
+        var attempt = function (mayMount) {
+            $.get(specUrl(candidate.base, '/' + UNIT_LIST)).done(function (data) {
+                var list = null;
+                try {
+                    list = parse(data);
+                }
+                catch (ex) {
+                    console.log(ex);
+                }
+                deferred.resolve(list && _.isArray(list.units) ? list.units : []);
+            }).fail(function () {
+                if (!mayMount || !candidate.zip) {
+                    deferred.resolve([]);
+                    return;
+                }
+                var mount = api.file.zip.mount(candidate.zip, candidate.base, false);
+                if (!mount || !_.isFunction(mount.then)) {
+                    deferred.resolve([]);
+                    return;
+                }
+                mount.then(function () {
+                    attempt(false);
+                }, function () {
+                    deferred.resolve([]);
+                });
+            });
+        };
+
+        attempt(true);
+        return deferred;
+    }
+
+    //unit_types is usually on the unit's own spec, but a spec is free to inherit it
+    function readSpec(candidate, path, hops, onDone) {
+        var handle = function (data) {
+            var spec = null;
+            try {
+                spec = parse(data);
+            }
+            catch (ex) {
+                console.log(ex);
+            }
+            if (!spec) {
+                onDone(null);
+                return;
+            }
+            if (spec.unit_types || !spec.base_spec || hops <= 0) {
+                onDone(spec);
+                return;
+            }
+            readSpec(candidate, spec.base_spec, hops - 1, function (base) {
+                if (base && base.unit_types) {
+                    spec.unit_types = base.unit_types;
+                    if (!spec.display_name) {
+                        spec.display_name = base.display_name;
+                    }
+                    if (!spec.description) {
+                        spec.description = base.description;
+                    }
+                }
+                onDone(spec);
+            });
+        };
+
+        //a base_spec often lives in the base game rather than in the mod
+        $.get(specUrl(candidate.base, path)).done(handle).fail(function () {
+            $.get(stockSpecUrl(path)).done(handle).fail(function () {
+                onDone(null);
+            });
+        });
+    }
+
+    function entryFor(spec) {
+        return {
+            name: spec.display_name,
+            description: spec.description,
+            types: spec.unit_types,
+            structure: _.contains(spec.unit_types, 'UNITTYPE_Structure')
+        };
+    }
+
+    function collect(candidates, known) {
+        var deferred = $.Deferred();
+        var found = {};
+        var seen = {};
+        var lists = candidates.length;
+        var specs = 0;
+
+        var finish = function () {
+            if (lists === 0 && specs === 0) {
+                deferred.resolve(found);
+            }
+        };
+
+        var take = function (candidate, path) {
+            var canonical = hbSpecId.canonical(path);
+            //the engine already has every stock unit, so only read what is new
+            if (known[canonical] || seen[canonical]) {
+                return;
+            }
+            seen[canonical] = true;
+            specs = specs + 1;
+            readSpec(candidate, path, BASE_SPEC_HOPS, function (spec) {
+                if (spec && spec.unit_types) {
+                    found[canonical] = entryFor(spec);
+                }
+                specs = specs - 1;
+                finish();
+            });
+        };
+
+        _.forEach(candidates, function (candidate) {
+            readUnitList(candidate).always(function (units) {
+                _.forEach(units, function (path) {
+                    take(candidate, path);
+                });
+                lists = lists - 1;
+                finish();
+            });
+        });
+
+        return deferred;
+    }
+
+    var modscan = {};
+
+    //resolves true when the unit cache gained something the picker should show.
+    //known is a map of canonical spec ids the picker already has.
+    modscan.run = function (known) {
+        var deferred = $.Deferred();
+
+        discover().always(function (candidates) {
+            var signature = signatureOf(candidates);
+            if (signature === hbUnitCache.signature()) {
+                deferred.resolve(false);
+                return;
+            }
+            if (!candidates.length) {
+                hbUnitCache.merge({}, signature);
+                deferred.resolve(false);
+                return;
+            }
+            collect(candidates, known || {}).done(function (found) {
+                hbUnitCache.merge(found, signature);
+                console.log("hotbuild mod scan added " + _.size(found) + " units");
+                deferred.resolve(_.size(found) > 0);
+            });
+        });
+
+        return deferred;
+    };
+
+    return modscan;
+
+})();
+
+console.log("loaded hotbuild2 mod scan");

--- a/ui/mods/hotbuild2/settings/hotbuild_settings.css
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.css
@@ -387,6 +387,11 @@ text-align: center;
 margin-right: -64px !important;
 }
 
+/* bound to a unit this game has no spec for, kept but unusable here */
+.hotbuild_list_item.hb_missing {
+	opacity: 0.4;
+}
+
 .hotbuild_list_item:hover, .hotbuild_list_item:active {
 	-webkit-filter: drop-shadow(0px 0px 4px rgba(255,255,255,1));
 }

--- a/ui/mods/hotbuild2/settings/hotbuild_settings.html
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.html
@@ -140,7 +140,7 @@
 
 
 
-<script id="leftTemplate" type="text/html"><div class="hotbuild_list_item">
+<script id="leftTemplate" type="text/html"><div class="hotbuild_list_item" data-bind="css: { hb_missing: hbmissing }">
         <div class="hotbuild_fab_selection">
             <span class="hotbuild_selected_text" data-bind="text: $index() + 1"></span>
             <img class="hotbuild_selected_fab" src="" data-bind="attr: { src: image }" alt="hbpreview">

--- a/ui/mods/hotbuild2/settings/hotbuild_settings.html
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.html
@@ -143,7 +143,7 @@
 <script id="leftTemplate" type="text/html"><div class="hotbuild_list_item" data-bind="css: { hb_missing: hbmissing }">
         <div class="hotbuild_fab_selection">
             <span class="hotbuild_selected_text" data-bind="text: $index() + 1"></span>
-            <img class="hotbuild_selected_fab" src="" data-bind="attr: { src: image }" alt="hbpreview">
+            <img class="hotbuild_selected_fab" src="" data-bind="attr: { src: image }" onerror="hbSpecId.fallbackIcon(this)" alt="hbpreview">
         </div>
         <div class="hotbuild_list_desc">
             <div class="hotbuild_list_desc_name" data-bind="text:displayname"></div>
@@ -154,7 +154,7 @@
 
 <script id="rightTemplate" type="text/html"><div class="hotbuild_list_item">
         <div class="hotbuild_fab_selection">
-            <img class="hotbuild_selected_fab" src="" data-bind="attr: { src: image }" alt="hbpreview">
+            <img class="hotbuild_selected_fab" src="" data-bind="attr: { src: image }" onerror="hbSpecId.fallbackIcon(this)" alt="hbpreview">
         </div>
         <div class="hotbuild_list_desc">
             <div class="hotbuild_list_desc_name" data-bind="text: displayname"></div>

--- a/ui/mods/hotbuild2/settings/hotbuild_settings.js
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.js
@@ -8,6 +8,8 @@ var hotbuildsettings = (function () {
 
     function HotBuildSettingsViewModel(hbglobal, hbglobalkey) {
         var self = this;
+        //migrate configs written before ids were stored untagged
+        hbSpecId.normaliseConfig(hbglobal);
         self.hotbuilddirty = ko.observable(false);
         self.hotbuildglobal = ko.observable(hbglobal).extend({ notify: 'always' });
         self.hotbuildglobalkey = ko.observable(hbglobalkey);
@@ -206,7 +208,11 @@ var hotbuildsettings = (function () {
                 viewmodelconfigkey['hotbuild' + nr + 's'] = copyconfigkey[hotkey];
                 viewmodelconfig['hotbuild' + nr + 's'] = [];
                 for (var i = 0; i < copyconfig[hotkey].length; i++) {
-                    viewmodelconfig['hotbuild' + nr + 's'].push({ 'json': copyconfig[hotkey][i].json });
+                    if (!copyconfig[hotkey][i] || !copyconfig[hotkey][i].json) {
+                        continue;
+                    }
+                    //store untagged so one mapping works under every spec tag
+                    viewmodelconfig['hotbuild' + nr + 's'].push({ 'json': hbSpecId.canonical(copyconfig[hotkey][i].json) });
                 }
                 nr++;
             }
@@ -326,7 +332,8 @@ var hotbuildsettings = (function () {
             self.keyboardkey('');
             console.log('HOTBUILD2 IMPORTING KEY CONFIG------------');
             self.hotbuildglobalkey(imported.hotbuildglobalkey);
-            self.hotbuildglobal(imported.hotbuildglobal);
+            //a .pas exported from a Galactic War session can hold tagged ids
+            self.hotbuildglobal(hbSpecId.normaliseConfig(imported.hotbuildglobal));
             updateExistingSettings();
             self.Save();
             console.log('WROTE HOTBUILD KEYS-----------');

--- a/ui/mods/hotbuild2/settings/hotbuild_settings.js
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.js
@@ -13,8 +13,10 @@ var hotbuildsettings = (function () {
         self.hotbuilddirty = ko.observable(false);
         self.hotbuildglobal = ko.observable(hbglobal).extend({ notify: 'always' });
         self.hotbuildglobalkey = ko.observable(hbglobalkey);
-        self.cleanhotbuildglobal = ko.observable(hbglobal);
-        self.cleanhotbuildglobalkey = ko.observable(hbglobalkey);
+        //copies, not the same objects: updateExistingSettings prunes hotbuildglobal in
+        //place and hotbuildStore writes these on any Save, hotbuild edit or not
+        self.cleanhotbuildglobal = ko.observable(_.cloneDeep(hbglobal));
+        self.cleanhotbuildglobalkey = ko.observable(_.cloneDeep(hbglobalkey));
         self.selectedhotbuild = ko.observableArray([]);
         self.filteredunits = ko.observableArray([]);
         self.units = ko.observableArray([]);
@@ -47,6 +49,10 @@ var hotbuildsettings = (function () {
         });
 
         function updateExistingSettings() {
+            //nothing to compare against yet, don't prune the config to nothing
+            if (self.units().length === 0) {
+                return;
+            }
             //now compare / update the existing hotbuildglobal data so it's always up 2 date
             for (var hbkey in self.hotbuildglobal()) {
                 //if(_.contains(self.units(),hb.json))

--- a/ui/mods/hotbuild2/settings/hotbuild_settings.js
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.js
@@ -21,32 +21,93 @@ var hotbuildsettings = (function () {
         self.filteredunits = ko.observableArray([]);
         self.units = ko.observableArray([]);
 
-        model.unitSpecs.subscribe(function (unitspecs) {
-            
-            if (unitspecs)
-            {
-                var filteredresults = [];
-                Object.keys(unitspecs).forEach(function(key,index) {
-                    //don't show commanders and debug units
-                    var unit = unitspecs[key];
-                    if (!_.contains(unit.types, 'UNITTYPE_Commander') && !_.contains(unit.types, 'UNITTYPE_Debug') && !_.contains(unit.types, 'UNITTYPE_NoBuild') ) {
-                        //console.log(unit);
-                        var hotbuildunit = {
-                            json: unit.id,
-                            displayname: loc(unit.name),
-                            desc: loc(unit.description),
-                            image: 'coui:/' + unit.id.replace('.json','_icon_buildbar.png'),
-                            types: unit.types,
-                            structure: unit.structure
-                        };
+        //in a Galactic War game the sim has a copy of every unit per spec tag, so the
+        //picker has to pick one of them to show. lower rank wins, cosmetic only.
+        self.hbSpecTag = null;
+        function hbTagRank(tag) {
+            if (self.hbSpecTag && tag === self.hbSpecTag) {
+                return 0;
+            }
+            if (tag === '') {
+                return 1;
+            }
+            if (tag === '.player') {
+                return 2;
+            }
+            return 3;
+        }
+
+        var hbUnitSpecs = null;
+        var hbFirstBuild = true;
+
+        self.hbBuildUnitList = function () {
+            if (!hbUnitSpecs) {
+                return;
+            }
+            var filteredresults = [];
+            var seen = {};
+            Object.keys(hbUnitSpecs).forEach(function(key,index) {
+                //don't show commanders and debug units
+                var unit = hbUnitSpecs[key];
+                if (unit && !_.contains(unit.types, 'UNITTYPE_Commander') && !_.contains(unit.types, 'UNITTYPE_Debug') && !_.contains(unit.types, 'UNITTYPE_NoBuild') ) {
+                    //console.log(unit);
+                    //the key is the spec id, unit.id is only set by crossRef in the live game scenes
+                    var canonical = hbSpecId.canonical(key);
+                    var rank = hbTagRank(hbSpecId.tag(key));
+                    var existing = seen[canonical];
+                    if (existing !== undefined && rank >= filteredresults[existing].hbrank) {
+                        return;
+                    }
+                    var hotbuildunit = {
+                        json: canonical,
+                        displayname: loc(unit.name),
+                        desc: loc(unit.description),
+                        image: hbSpecId.buildBarIcon(canonical),
+                        types: unit.types,
+                        structure: unit.structure,
+                        hbrank: rank
+                    };
+                    if (existing === undefined) {
+                        seen[canonical] = filteredresults.length;
                         filteredresults.push(hotbuildunit);
                     }
-                });
-                self.units(filteredresults);
+                    else {
+                        filteredresults[existing] = hotbuildunit;
+                    }
+                }
+            });
+            self.units(filteredresults);
+            if (hbFirstBuild) {
+                hbFirstBuild = false;
                 self.filteredunits(_.filter(filteredresults, function(u){ return u.structure; })); //set standard on all buildings
-                updateExistingSettings(); 
-            }                             
+            }
+            else {
+                self.filterunits(); //rebuilt underneath the user, keep them on their filter
+            }
+            updateExistingSettings();
+        };
+
+        model.unitSpecs.subscribe(function (unitspecs) {
+            if (unitspecs)
+            {
+                hbUnitSpecs = unitspecs;
+                self.hbBuildUnitList();
+            }
         });
+
+        //never gate the picker on this, it may never resolve outside a game
+        try {
+            var hbTagRequest = api.game.getUnitSpecTag();
+            if (hbTagRequest && _.isFunction(hbTagRequest.then)) {
+                hbTagRequest.then(function (tag) {
+                    self.hbSpecTag = tag || '';
+                    self.hbBuildUnitList();
+                });
+            }
+        }
+        catch (ex) {
+            console.log(ex);
+        }
 
         function updateExistingSettings() {
             //nothing to compare against yet, don't prune the config to nothing

--- a/ui/mods/hotbuild2/settings/hotbuild_settings.js
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.js
@@ -40,42 +40,55 @@ var hotbuildsettings = (function () {
         var hbUnitSpecs = null;
         var hbFirstBuild = true;
 
+        //worse than any spec tag, so anything the engine sends wins over a stored copy
+        var HB_STORED_RANK = 4;
+
         self.hbBuildUnitList = function () {
-            if (!hbUnitSpecs) {
-                return;
-            }
             var filteredresults = [];
             var seen = {};
-            Object.keys(hbUnitSpecs).forEach(function(key,index) {
+
+            var consider = function (key, unit, rank) {
                 //don't show commanders and debug units
-                var unit = hbUnitSpecs[key];
-                if (unit && !_.contains(unit.types, 'UNITTYPE_Commander') && !_.contains(unit.types, 'UNITTYPE_Debug') && !_.contains(unit.types, 'UNITTYPE_NoBuild') ) {
-                    //console.log(unit);
-                    //the key is the spec id, unit.id is only set by crossRef in the live game scenes
-                    var canonical = hbSpecId.canonical(key);
-                    var rank = hbTagRank(hbSpecId.tag(key));
-                    var existing = seen[canonical];
-                    if (existing !== undefined && rank >= filteredresults[existing].hbrank) {
-                        return;
-                    }
-                    var hotbuildunit = {
-                        json: canonical,
-                        displayname: loc(unit.name),
-                        desc: loc(unit.description),
-                        image: hbSpecId.buildBarIcon(canonical),
-                        types: unit.types,
-                        structure: unit.structure,
-                        hbrank: rank
-                    };
-                    if (existing === undefined) {
-                        seen[canonical] = filteredresults.length;
-                        filteredresults.push(hotbuildunit);
-                    }
-                    else {
-                        filteredresults[existing] = hotbuildunit;
-                    }
+                if (!unit || _.contains(unit.types, 'UNITTYPE_Commander') || _.contains(unit.types, 'UNITTYPE_Debug') || _.contains(unit.types, 'UNITTYPE_NoBuild')) {
+                    return;
                 }
+                //the key is the spec id, unit.id is only set by crossRef in the live game scenes
+                var canonical = hbSpecId.canonical(key);
+                var existing = seen[canonical];
+                if (existing !== undefined && rank >= filteredresults[existing].hbrank) {
+                    return;
+                }
+                var hotbuildunit = {
+                    json: canonical,
+                    displayname: loc(unit.name),
+                    desc: loc(unit.description),
+                    image: hbSpecId.buildBarIcon(canonical),
+                    types: unit.types,
+                    structure: unit.structure,
+                    hbrank: rank
+                };
+                if (existing === undefined) {
+                    seen[canonical] = filteredresults.length;
+                    filteredresults.push(hotbuildunit);
+                }
+                else {
+                    filteredresults[existing] = hotbuildunit;
+                }
+            };
+
+            //a server mod's units are not in this client's spec set outside a game, so
+            //start from what a real game reported and what the mod scan read off disk
+            var stored = hbUnitCache.load();
+            Object.keys(stored).forEach(function (key) {
+                consider(key, stored[key], HB_STORED_RANK);
             });
+
+            if (hbUnitSpecs) {
+                Object.keys(hbUnitSpecs).forEach(function (key) {
+                    consider(key, hbUnitSpecs[key], hbTagRank(hbSpecId.tag(key)));
+                });
+            }
+
             self.units(filteredresults);
             if (hbFirstBuild) {
                 hbFirstBuild = false;
@@ -91,9 +104,47 @@ var hotbuildsettings = (function () {
             if (unitspecs)
             {
                 hbUnitSpecs = unitspecs;
+                //opened from inside a game this is the sim's set, server mod units and all
+                hbUnitCache.harvest(unitspecs);
                 self.hbBuildUnitList();
+                hbRunModScan();
             }
         });
+
+        //every unit the picker can already account for, so the scan reads only the rest
+        function hbKnownIds() {
+            var known = {};
+            var stored = hbUnitCache.load();
+            for (var id in stored) {
+                known[id] = true;
+            }
+            var specs = model.unitSpecs();
+            for (var key in specs) {
+                known[hbSpecId.canonical(key)] = true;
+            }
+            return known;
+        }
+
+        //read the enabled server mods for units this client has no specs for. async and
+        //off the critical path: the picker already shows the engine's units. waits for the
+        //first spec payload so every stock unit counts as known and is not read again.
+        var hbScanned = false;
+        function hbRunModScan() {
+            if (hbScanned) {
+                return;
+            }
+            hbScanned = true;
+            try {
+                hbModScan.run(hbKnownIds()).done(function (gained) {
+                    if (gained) {
+                        self.hbBuildUnitList();
+                    }
+                });
+            }
+            catch (ex) {
+                console.log(ex);
+            }
+        }
 
         //never gate the picker on this, it may never resolve outside a game
         try {

--- a/ui/mods/hotbuild2/settings/hotbuild_settings.js
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.js
@@ -109,6 +109,20 @@ var hotbuildsettings = (function () {
             console.log(ex);
         }
 
+        //a binding this spec set has no unit for, e.g. a Legion unit in a vanilla game.
+        //shown greyed and kept, so it survives back into localStorage on the next save.
+        function hbMissingUnit(json) {
+            return {
+                json: json,
+                displayname: json.replace(/^.*\//, '').replace(/\.json$/, ''),
+                desc: 'NOT AVAILABLE HERE',
+                image: hbSpecId.buildBarIcon(json),
+                types: [],
+                structure: false,
+                hbmissing: true
+            };
+        }
+
         function updateExistingSettings() {
             //nothing to compare against yet, don't prune the config to nothing
             if (self.units().length === 0) {
@@ -116,16 +130,15 @@ var hotbuildsettings = (function () {
             }
             //now compare / update the existing hotbuildglobal data so it's always up 2 date
             for (var hbkey in self.hotbuildglobal()) {
-                //if(_.contains(self.units(),hb.json))
-                for (var i = 0; i < self.hotbuildglobal()[hbkey].length; i++) {
-                    var match = _.find(self.units(), { 'json': self.hotbuildglobal()[hbkey][i].json });
-                    self.hotbuildglobal()[hbkey][i] = match;
-                }
+                var entries = self.hotbuildglobal()[hbkey];
                 var goodstuff = [];
-                for (i = 0; i < self.hotbuildglobal()[hbkey].length; i++) {
-                    if (self.hotbuildglobal()[hbkey][i] !== undefined) {
-                        goodstuff.push(self.hotbuildglobal()[hbkey][i]);
+                for (var i = 0; i < entries.length; i++) {
+                    if (!entries[i] || !entries[i].json) {
+                        continue;
                     }
+                    var json = hbSpecId.canonical(entries[i].json);
+                    var match = _.find(self.units(), { 'json': json });
+                    goodstuff.push(match !== undefined ? match : hbMissingUnit(json));
                 }
                 self.hotbuildglobal()[hbkey] = goodstuff;
             }

--- a/ui/mods/hotbuild2/shared/hotbuild_specid.js
+++ b/ui/mods/hotbuild2/shared/hotbuild_specid.js
@@ -40,6 +40,13 @@ var hbSpecId = (function () {
         return 'coui:/' + match[1] + '_icon_buildbar.png';
     };
 
+    //the path is a convention, not a guarantee: a mod's internal spawn units have no
+    //build bar art. onerror handler, so clear it first or a missing fallback loops.
+    specid.fallbackIcon = function (img) {
+        img.onerror = null;
+        img.src = MISSING_ICON;
+    };
+
     //first entry of list whose .id is the same unit, whatever tag either carries
     specid.findSpec = function (list, id) {
         var canon = specid.canonical(id);

--- a/ui/mods/hotbuild2/shared/hotbuild_specid.js
+++ b/ui/mods/hotbuild2/shared/hotbuild_specid.js
@@ -1,0 +1,75 @@
+console.log("loading hotbuild2 spec id helper");
+
+var hbSpecId = (function () {
+
+    //same expressions stock PA uses: build.js and live_game_build_bar.js
+    var CANONICAL = /(.*\.json)[^\/]*$/;
+    var NOEXTENSION = /(.*)\.json[^\/]*$/;
+    var MISSING_ICON = 'coui://ui/main/game/live_game/img/build_bar/img_missing_unit.png';
+
+    var specid = {};
+
+    //'/pa/x/y.json.player1' -> '/pa/x/y.json' , untagged ids pass through
+    specid.canonical = function (id) {
+        if (!id) {
+            return id;
+        }
+        var match = CANONICAL.exec(id);
+        return (match && match[1]) ? match[1] : id;
+    };
+
+    //'/pa/x/y.json.player1' -> '.player1' , untagged ids give ''
+    specid.tag = function (id) {
+        if (!id) {
+            return '';
+        }
+        var canon = specid.canonical(id);
+        return (id.length > canon.length) ? id.slice(canon.length) : '';
+    };
+
+    specid.same = function (a, b) {
+        return specid.canonical(a) === specid.canonical(b);
+    };
+
+    //the settings scene has no Build global, build.js isn't in settings.html
+    specid.buildBarIcon = function (id) {
+        var match = id ? NOEXTENSION.exec(id) : null;
+        if (!match || !match[1]) {
+            return MISSING_ICON;
+        }
+        return 'coui:/' + match[1] + '_icon_buildbar.png';
+    };
+
+    //first entry of list whose .id is the same unit, whatever tag either carries
+    specid.findSpec = function (list, id) {
+        var canon = specid.canonical(id);
+        var count = list ? list.length : 0;
+        for (var i = 0; i < count; i++) {
+            if (list[i] && specid.canonical(list[i].id) === canon) {
+                return list[i];
+            }
+        }
+        return undefined;
+    };
+
+    //in place, never adds/removes/reorders hotbuildNs keys
+    specid.normaliseConfig = function (config) {
+        for (var hotkey in config) {
+            var entries = config[hotkey];
+            if (!entries || entries.length === undefined) {
+                continue;
+            }
+            for (var i = 0; i < entries.length; i++) {
+                if (entries[i] && entries[i].json) {
+                    entries[i].json = specid.canonical(entries[i].json);
+                }
+            }
+        }
+        return config;
+    };
+
+    return specid;
+
+})();
+
+console.log("loaded hotbuild2 spec id helper");

--- a/ui/mods/hotbuild2/shared/hotbuild_unitcache.js
+++ b/ui/mods/hotbuild2/shared/hotbuild_unitcache.js
@@ -1,0 +1,133 @@
+console.log("loading hotbuild2 unit cache");
+
+var hbUnitCache = (function () {
+
+    var STORE = 'hotbuildunitcache';
+    var VERSION = 1;
+
+    var cache = null;
+
+    //an id the engine never sends, e.g. message_type, is not a unit
+    function isSpecId(id) {
+        return !!id && id.indexOf('.json') !== -1;
+    }
+
+    //untagged wins, then this client's army, then any other tag. same ordering the
+    //settings picker uses, so the copy stored is the one it would have shown.
+    function tagRank(tag) {
+        if (tag === '') {
+            return 0;
+        }
+        if (tag === '.player') {
+            return 1;
+        }
+        return 2;
+    }
+
+    function read() {
+        var stored = null;
+        try {
+            stored = localStorage[STORE] ? decode(localStorage[STORE]) : null;
+        }
+        catch (ex) {
+            console.log("hotbuild unit cache unreadable, starting empty");
+            console.log(ex);
+        }
+        if (!stored || stored.v !== VERSION || !stored.units) {
+            return { v: VERSION, sig: '', units: {} };
+        }
+        return stored;
+    }
+
+    function write(store) {
+        try {
+            localStorage[STORE] = encode(store);
+        }
+        catch (ex) {
+            //a full quota must not take the picker down with it
+            console.log("hotbuild unit cache could not be saved");
+            console.log(ex);
+        }
+    }
+
+    var unitcache = {};
+
+    //{name, description, types, structure} per canonical spec id, the same fields
+    //the engine sends, so a cached entry drops straight into hbBuildUnitList
+    unitcache.load = function () {
+        cache = read();
+        return cache.units;
+    };
+
+    unitcache.signature = function () {
+        cache = read();
+        return cache.sig;
+    };
+
+    function same(stored, unit) {
+        return !!stored
+            && stored.name === unit.name
+            && stored.description === unit.description
+            && stored.structure === !!unit.structure
+            && String(stored.types) === String(unit.types);
+    }
+
+    //the sim's own spec set, whatever supplied it. authoritative, so it overwrites.
+    unitcache.harvest = function (payload) {
+        if (!payload) {
+            return;
+        }
+        cache = read();
+        var best = {};
+        var changed = false;
+        for (var id in payload) {
+            if (!isSpecId(id)) {
+                continue;
+            }
+            var unit = payload[id];
+            if (!unit || !unit.types) {
+                continue;
+            }
+            var canonical = hbSpecId.canonical(id);
+            var rank = tagRank(hbSpecId.tag(id));
+            //a better ranked copy of this unit already came out of this payload
+            if (best[canonical] !== undefined && rank >= best[canonical]) {
+                continue;
+            }
+            best[canonical] = rank;
+            if (same(cache.units[canonical], unit)) {
+                continue;
+            }
+            changed = true;
+            cache.units[canonical] = {
+                name: unit.name,
+                description: unit.description,
+                types: unit.types,
+                structure: !!unit.structure
+            };
+        }
+        //every settings open replays the same payload, so only write a real change
+        if (!changed) {
+            return;
+        }
+        write(cache);
+    };
+
+    //units read off disk by the mod scan. lower trust than a harvest, so it only
+    //fills gaps, and sig records which mod set produced them.
+    unitcache.merge = function (extra, sig) {
+        cache = read();
+        for (var id in extra) {
+            if (!cache.units[id]) {
+                cache.units[id] = extra[id];
+            }
+        }
+        cache.sig = sig;
+        write(cache);
+    };
+
+    return unitcache;
+
+})();
+
+console.log("loaded hotbuild2 unit cache");


### PR DESCRIPTION
Currently the only way to build hotkeys for third-party units is to do so with the mod mounted in `live_game`.

This pull builds on pull #44 and introduces two changes:

1. Units in `live_game` are cached so that `settings` can read them at any time.
2. Units outside the cache are read directly from the mod zips so that keys can be mapped without any games having been played.

This adds ~44ms to the `settings` scene load.

Only 4c71aea is new work beyond what #44 already adds.