### PR TITLE
Fix all build bar entries all having the same character

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -4,7 +4,7 @@
     "display_name": "Hotbuild2",
     "description": "Map 1 Key to multiple build actions and more... (See forum link for screenshots and instructions.)",
     "author": "proeleert, tripax, cola_colin, quitch, claude",
-    "version": "1.53",
+    "version": "1.54",
     "build": "124670",
     "date": "2026-08-13",
     "signature": " ",

--- a/ui/mods/hotbuild2/live_game/hotbuild_buildbar.js
+++ b/ui/mods/hotbuild2/live_game/hotbuild_buildbar.js
@@ -16,14 +16,14 @@ var hotbuild2buildbar = (function () {
 
     hbgetBuildBarKey = function (id) {
         var result = '';
-        var hbpos = 1;
         //the build bar hands us tagged ids in Galactic War, ours are stored untagged
         var canonical = hbSpecId.canonical(id);
-        _.forEach(hotbuildglobal, function (hbkey) {
+        //the two configs are joined by property name, so look the key up by name
+        _.forEach(hotbuildglobal, function (hbkey, hbname) {
             _.forEach(hbkey, function (hbitem) {
                 if (hbitem && hbSpecId.canonical(hbitem.json) === canonical) {
-                    if (hotbuildglobalkey["hotbuild" + hbpos + "s"] !== undefined) {
-                        result += hotbuildglobalkey["hotbuild" + hbpos + "s"];
+                    if (hotbuildglobalkey[hbname] !== undefined) {
+                        result += hotbuildglobalkey[hbname];
                         return false;
                     }
                 }

--- a/ui/mods/hotbuild2/live_game/hotbuild_selection.js
+++ b/ui/mods/hotbuild2/live_game/hotbuild_selection.js
@@ -16,14 +16,14 @@ var hotbuild2selection = (function () {
 
     hbgetBuildBarKey = function (id) {
         var result = '';
-        var hbpos = 1;
         //the selection hands us tagged ids in Galactic War, ours are stored untagged
         var canonical = hbSpecId.canonical(id);
-        _.forEach(hotbuildglobal, function (hbkey) {
+        //the two configs are joined by property name, so look the key up by name
+        _.forEach(hotbuildglobal, function (hbkey, hbname) {
             _.forEach(hbkey, function (hbitem) {
                 if (hbitem && hbSpecId.canonical(hbitem.json) === canonical) {
-                    if (hotbuildglobalkey["hotbuild" + hbpos + "s"] !== undefined) {
-                        result += hotbuildglobalkey["hotbuild" + hbpos + "s"];
+                    if (hotbuildglobalkey[hbname] !== undefined) {
+                        result += hotbuildglobalkey[hbname];
                         return false;
                     }
                 }


### PR DESCRIPTION
**Root cause:** in hotbuild_buildbar.js:17-33, `hbpos` is initialised to 1 and never incremented. Every unit that has a binding therefore reads `hotbuildglobalkey["hotbuild1s"]`, so the whole build bar renders whatever letter that user bound to hotbuild slot 1 (in the QUITCH default, `w`). That explains both symptoms exactly: one letter everywhere, and a different letter per user. It's cosmetic because the actual key handling in `hotbuild_core.js` looks bindings up by name, never by this counter.

**How it got there:** commit ab00c86 ("Look up the hotbuild key by name, not position") deleted the counter on main and switched to a name lookup. In parallel, facc316 on `patch/spec-tags` added canonical-id matching to the old counter-based body. The merge 138352c resolved that conflict by keeping the spec-tags body but also accepting `main`'s deletion of the `hbpos += 1;` line — leaving a counter that is read but never advanced. The pre-merge branch tip acdcf8b still had the increment, so the defect was created by the merge resolution itself and shipped in 1.53.

The same bug is in hotbuild_selection.js:17-33 — an identical copy of the function, so the selection-panel labels are wrong the same way.

**The fix** is to restore ab00c86's approach rather than re-add `hbpos += 1;`. I confirmed both config objects are keyed identically (`hotbuild1s`, `hotbuild2s`, … in both `hotbuildglobal` and `hotbuildglobalkey`, 14 entries each in QUITCH.json), so the name lookup is sound and, unlike the counter, doesn't rely on the two objects being sequentially numbered and iterated in the same order. That keeps the canonical-id matching from the spec-tags work and drops `hbpos` entirely, in both files.

**Testing:** loaded into a Skirmish and confirmed correct letters are assigned to each structure on the Commander and that keys remain functional.

**Additional:** bumped `version` for you.