### PR TITLE
Assigned unit names and icons missing on keymap

### DIFF
--- a/ui/mods/hotbuild2/settings/hotbuild_settings.html
+++ b/ui/mods/hotbuild2/settings/hotbuild_settings.html
@@ -140,7 +140,7 @@
 
 
 
-<script id="leftTemplate" type="text/html"><div class="hotbuild_list_item" data-bind="css: { hb_missing: hbmissing }">
+<script id="leftTemplate" type="text/html"><div class="hotbuild_list_item" data-bind="css: { hb_missing: $data.hbmissing }">
         <div class="hotbuild_fab_selection">
             <span class="hotbuild_selected_text" data-bind="text: $index() + 1"></span>
             <img class="hotbuild_selected_fab" src="" data-bind="attr: { src: image }" onerror="hbSpecId.fallbackIcon(this)" alt="hbpreview">


### PR DESCRIPTION
When you selected a key, or assigned a unit to a key, the settings UI was not showing the unit's name or icon. This fixes that.

Key bindings were not impacted.